### PR TITLE
Add functionality to allow for pattern matching using globbing

### DIFF
--- a/gitrelevanthistory/main.py
+++ b/gitrelevanthistory/main.py
@@ -153,8 +153,8 @@ def main():
     if arguments["--branch"]:
         branch = arguments["--branch"]
 
-    glob_filter_file = "False"
-    if arguments["--glob"] or arguments["-g"]:
+    glob_filter_file = False
+    if arguments["--glob"]:
         glob_filter_file = True
 
     target_repo = pathlib.Path(arguments["--target"]).expanduser().absolute()


### PR DESCRIPTION
Small addition to let filter files specify patterns instead of fixed file paths. If patterns are being used, include --glob on the command line and provide a file with names like "file1.*", one per line. Globbing is off by default.